### PR TITLE
Fix mixed content type warnings by using protocol-relative URL to fetch PDB files

### DIFF
--- a/flask_server.py
+++ b/flask_server.py
@@ -92,6 +92,7 @@ def compile_jolecule_js():
 @app.route('/js/<path:path>')
 def get_js_file(path):
     fname = os.path.join(root_dir, 'js', path)
+    text = None
     if fname.endswith('jolecule.js'):
         text = compile_jolecule_js()
     elif os.path.isfile(fname):

--- a/js/dataserver.js
+++ b/js/dataserver.js
@@ -5,7 +5,7 @@ jolecule_server = function(pdb_id) {
     pdb_id: pdb_id,
     get_protein_data: function(process_protein_data) {
         if (pdb_id.length == 4) {
-            var url = 'http://www.rcsb.org/pdb/files/' + pdb_id + '.pdb'
+            var url = '//files.rcsb.org/view/' + pdb_id + '.pdb'
         } else {
             var url = '/pdb/' + pdb_id + '.txt'
         }


### PR DESCRIPTION
Required switching from www.rcsb.org/pdb/files/ to files.rcsb.org/view/ since the former doesn't support HTTPS at this time.
