### PR TITLE
Update package.json to support installation via package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "jolecule",
+  "version": "2.0.0",
+  "main": "src/main.js",
   "scripts": {
     "test": "cd test && ./test.sh",
     "format": "prettier-standard src/*js && eslint --fix src/*js"


### PR DESCRIPTION
Adds missing name, version and main keys to package.json which enables consumers to ```npm i bocoh/jolecule``` and bundle the source themselves as part of their own build step.